### PR TITLE
fix post (portfolio) item display issue

### DIFF
--- a/_posts/2021-10-01-title-1.markdown
+++ b/_posts/2021-10-01-title-1.markdown
@@ -10,5 +10,5 @@ alt: image-alt
 project-date: Fall 2021
 client: White Oak High School - Jacksonville, NC
 category: Marching Band
-description: "On Greater Shores" is a tribute to nordic heritage and their conquests across the seas. Music selections including "Come Sail Away" by Styx, "Test Drive" by John Powell, and traditional folk selections. Program design by Ryan Wilhite, Winds arranged by Brighton Barrineau and Trevor Schachner, Percussion by Justin Bui and Theo Richardson, Sound design by Danny Gutierrez.
+description: '"On Greater Shores" is a tribute to nordic heritage and their conquests across the seas. Music selections including "Come Sail Away" by Styx, "Test Drive" by John Powell, and traditional folk selections. Program design by Ryan Wilhite, Winds arranged by Brighton Barrineau and Trevor Schachner, Percussion by Justin Bui and Theo Richardson, Sound design by Danny Gutierrez.'
 ---


### PR DESCRIPTION
YAML syntax didn't like that the `description` field started with a quotation mark (`"`). I wrapped the whole field in single quotes so that it was clear the full line is the value. This fixed the portfolio item display on the site.